### PR TITLE
Laravel 8 Configuration Serialization

### DIFF
--- a/src/config/contentful.php
+++ b/src/config/contentful.php
@@ -12,10 +12,6 @@ declare(strict_types=1);
 use Contentful\Delivery\ClientOptions;
 use Illuminate\Foundation\Application;
 
-$deliveryOptionsClosure = function (ClientOptions $options, Application $application) {
-    // Update $options however you prefer
-};
-
 return [
     'delivery' => [
         /*
@@ -44,9 +40,8 @@ return [
         'defaultLocale' => env('CONTENTFUL_DEFAULT_LOCALE'),
 
         /*
-         * A closure which manipulates a ClientOptions object.
-         * See Contentful\Delivery\ClientOptions for more.
-         */
-        'options' => $deliveryOptionsClosure,
+        * An array of further client options. See Contentful\Delivery\Client::__construct() for more.
+        */
+        'delivery.options' => [],
     ],
 ];


### PR DESCRIPTION
Hi there,

Thank you for upgrading the package to allow support for Laravel 8 applications.

It seems there's an issue with this release within `src/config/contentful.php`. Laravel does not allow for closures within configuration files.
https://stackoverflow.com/questions/52065513/your-configuration-files-are-not-serializable

Using the current 7 branch, if you run `php artisan config:cache` you will be presented with the following error.

```
Configuration cache cleared!
   LogicException 
  Your configuration files are not serializable.
  at vendor/laravel/framework/src/Illuminate/Foundation/Console/ConfigCacheCommand.php:71
     67▕             require $configPath;
     68▕         } catch (Throwable $e) {
     69▕             $this->files->delete($configPath);
     70▕ 
  ➜  71▕             throw new LogicException('Your configuration files are not serializable.', 0, $e);
     72▕         }
     73▕ 
     74▕         $this->info('Configuration cached successfully!');
     75▕     }
  1   bootstrap/cache/config.php:276
      Error::("Call to undefined method Closure::__set_state()")
      +27 vendor frames
  29  artisan:37
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Co
nsole\Output\ConsoleOutput))
``` 

This feature is particularly import for applications that use Laravel Vapor, as we are unable to deploy out applications while a closure remains. 
